### PR TITLE
Fixed tab grouping broken under Vivaldi 5.3

### DIFF
--- a/src/tabs_helpers.ts
+++ b/src/tabs_helpers.ts
@@ -14,12 +14,12 @@ export interface RulesConfig {
   }
   
   interface VivaldiTab extends chrome.tabs.Tab {
-    readonly extData: string;
+    readonly vivExtData: string;
   }
   
   
   interface VivaldiUpdateProperties extends chrome.tabs.UpdateProperties {
-    extData?: string;
+    vivExtData?: string;
   }
  
 export type RemovePromise = (tabId: number) => Promise<any>
@@ -29,7 +29,7 @@ export type RegroupTabsPromise = (tabs: chrome.tabs.Tab[]) => Promise<chrome.tab
   
   
   const isVivaldiTab = (object: any): object is VivaldiTab => {
-    return object && 'extData' in object;
+    return object && 'vivExtData' in object;
   };
   
   function uuidv4(): string {
@@ -160,7 +160,7 @@ export const groupVivaldiTabsPromise = (tabs: VivaldiTab[], updatePromise: Updat
     .filter(t => t.id !== undefined)
     .reduce( (old, curr) => {
         var data = {}
-        try { data = JSON.parse(curr.extData) } catch(e) {}
+        try { data = JSON.parse(curr.vivExtData) } catch(e) {}
 
         return {
           ...old,
@@ -184,7 +184,7 @@ export const groupVivaldiTabsPromise = (tabs: VivaldiTab[], updatePromise: Updat
     const newExtData = tabsToExtData[tabId]
     newExtData.group = groupIdToUse
 
-    return () => updatePromise(tabId, { extData : JSON.stringify(newExtData) } );
+    return () => updatePromise(tabId, { vivExtData : JSON.stringify(newExtData) } );
   }))
   return promiseSerial(updatePromises)
 }


### PR DESCRIPTION
Starting with at least Vivaldi 5.3.2679.51, grouping functionality no longer works correctly. From what I could figure out while debugging, the code no longer runs Vivaldi-specific paths, as `extData` is no longer part of the tab objects.

Still, there's `vivExtData`, that looks like a new name for the same field:

<img width="633" alt="Screen Shot 2022-06-10 at 23 15 38" src="https://user-images.githubusercontent.com/803905/173152327-2452e637-b226-4c55-9f26-e82a466f9427.png">

This PR adjusts the code for the new field name, and from what I can see, as result, the grouping functionality is working fine again.