### PR TITLE
Migrate manifest v2 -> v3

### DIFF
--- a/static/background.html
+++ b/static/background.html
@@ -1,2 +1,0 @@
-<script type="module" src="background.js"></script>
-<script type="module" src="tabs_helpers.js"></script>

--- a/static/index.html
+++ b/static/index.html
@@ -25,7 +25,7 @@
 
       </div>
 
-      <script src='./popup.js'></script>
+      <script type='module' src='./popup.js'></script>
       <script src='./localise.js'></script>
 
     </body>

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,28 +1,24 @@
 {
-    "name": "Otto Tabs",
-    "description": "__MSG_manifest_description__",
-    "default_locale": "en",
-    "version": "0.3.0",
-    "manifest_version": 2,
-    "permissions": ["tabs", "storage"],
-    "browser_action": {
-      "default_popup": "index.html"
-    },
-    "background": {
-      "page": "background.html",
-      "persistent": false
-    },
-    "commands": {    },
-    "icons": { 
-      "48": "ic_launcher_round_48.png",
-      "72": "ic_launcher_round_72.png",
-      "96": "ic_launcher_round_96.png",
-      "144": "ic_launcher_round_144.png",
-      "192": "ic_launcher_round_192.png"
-    }
-  }
-
-  
-
-
-
+	"name": "Otto Tabs",
+	"description": "__MSG_manifest_description__",
+	"default_locale": "en",
+	"version": "0.3.0",
+	"manifest_version": 3,
+	"minimum_chrome_version": "88",
+	"permissions": ["tabs","storage"],
+	"action": {
+		"default_popup": "index.html"
+	},
+	"background": {
+		"service_worker": "background.js",
+		"type": "module"
+	},
+	"commands": {},
+	"icons": {
+		"48": "ic_launcher_round_48.png",
+		"72": "ic_launcher_round_72.png",
+		"96": "ic_launcher_round_96.png",
+		"144": "ic_launcher_round_144.png",
+		"192": "ic_launcher_round_192.png"
+	}
+}


### PR DESCRIPTION
Loading this extension as-is throws a warning about v2's deprecation.
This is in preparation for: https://developer.chrome.com/docs/extensions/mv3/mv2-sunset/
Following: https://developer.chrome.com/docs/extensions/mv3/mv3-migration/#man-sw

The extension's version number should probably be incremented as well.
(Either in this commit or one directly following it.)

I'm running this on Vivalid and it seems to work (when on top of https://github.com/borsini/chrome-otto-tabs/pull/11), but otherwise this is not extensively tested.

***

Extra note:
It doesn't seem required, but it might be better to move `background.js`'s content to another file.
Then change `bacground.js` to something that looks like the (now deleted) `background.html` page, except using `importScripts` instead of `<script>` tags.
As-is, `background.ts` seems to import `./tabs_helpers.js` anyway/explicitly so it doesn't seem to make a difference when iusing `"type": "module"`.